### PR TITLE
Add Favorites to frontend

### DIFF
--- a/src/WebUI.Client/Components/Layout/FavoritesCounter.razor
+++ b/src/WebUI.Client/Components/Layout/FavoritesCounter.razor
@@ -1,0 +1,21 @@
+﻿@using WebUI.Client.Ports
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+@inject IFavoriteUIService FavoriteUIService
+@implements IDisposable
+
+<div class="mx-6 my-3">
+    @if (FavoriteUIService.Favorites.Count == 0)
+    {
+        <a href="favorites">
+            <MudIcon Href="favorites" Icon="@Icons.Material.Filled.Star" Size="Size.Large" />
+        </a>
+    }
+    else
+    {
+        <MudBadge Content="FavoriteUIService.Favorites.Count" Color="Color.Error" Overlap="true">
+            <a href="favorites">
+                <MudIcon Icon="@Icons.Material.Filled.Star" Size="Size.Large" />
+            </a>
+        </MudBadge>
+    }
+</div>

--- a/src/WebUI.Client/Components/Layout/FavoritesCounter.razor.cs
+++ b/src/WebUI.Client/Components/Layout/FavoritesCounter.razor.cs
@@ -1,0 +1,15 @@
+﻿namespace WebUI.Client.Components.Layout;
+
+public sealed partial class FavoritesCounter
+{
+    protected override void OnInitialized()
+    {
+        FavoriteUIService.OnFavoritesChanged += StateHasChanged;
+        FavoriteUIService.GetFavoritesAsync();
+    }
+
+    public void Dispose()
+    {
+        FavoriteUIService.OnFavoritesChanged -= StateHasChanged;
+    }
+}

--- a/src/WebUI.Client/Components/Layout/Search.razor
+++ b/src/WebUI.Client/Components/Layout/Search.razor
@@ -29,7 +29,7 @@
     }
 </style>
 
-<div class="input-group">
+<div class="input-group mx-5">
     <input class="form-control"
            type="search"
            list="products"

--- a/src/WebUI.Client/Components/Layout/ShopLayout.razor
+++ b/src/WebUI.Client/Components/Layout/ShopLayout.razor
@@ -29,6 +29,11 @@
         <HomeButton />
         <MudSpacer />
         <Search />
+        <AuthorizeView>
+            <Authorized>
+                <FavoritesCounter />
+            </Authorized>
+        </AuthorizeView>
         <CartCounter />
     </MudAppBar>
     <MudMainContent>


### PR DESCRIPTION
Implements the frontend and interactivity for favorites. The idea is to have favorites as a part of the layout and have a page for favorites which easily gives the user an overview and the opportunity to adjust the list as they wish. On the ProductDetails there should of course be added the opportunity to add and remove said product from the list of favorites.

The favorites feature should only work for users that are logged in.